### PR TITLE
[Display] Adds option to display the created population, industry, and city gates

### DIFF
--- a/perlin.py
+++ b/perlin.py
@@ -22,7 +22,7 @@ import sumolib
 # POPULATION_BASE = random.randrange(-1000, 1000)
 POPULATION_BASE: float = 0
 # INDUSTRY_BASE = random.randrange(-1000, 1000)
-INDUSTRY_BASE: float = 2
+INDUSTRY_BASE: float = 100
 
 
 def get_edge_pair_centroid(coords: List[Tuple[float, float]]) -> Tuple[float, float]:

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -10,7 +10,7 @@ Output Options:
 
 Other Options:
     --gates.count N             Number of city gates in the city [default: 4]
-    --display                   Displays a image of cities elements and the noise used to generate them
+    --display                   Displays an image of cities elements and the noise used to generate them.
     -h, --help                  Show this screen.
     --version                   Show version.
 """
@@ -149,7 +149,7 @@ def main():
     # Write statistics back
     stats.write(args["--output-file"])
 
-    if (args["--display"]):
+    if args["--display"]:
         display_network(net, stats, 500, 500)
 
 

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -1,5 +1,5 @@
 """
-Usage: randomActivityGen.py --net-file=FILE --stat-file=FILE --output-file=FILE [--gates.count=N]
+Usage: randomActivityGen.py --net-file=FILE --stat-file=FILE --output-file=FILE [--gates.count=N] [--display]
 
 Input Options:
     -n, --net-file FILE         Input road network file to create activity for
@@ -10,6 +10,7 @@ Output Options:
 
 Other Options:
     --gates.count N             Number of city gates in the city [default: 4]
+    --display                   Displays a image of cities elements and the noise used to generate them
     -h, --help                  Show this screen.
     --version                   Show version.
 """
@@ -23,6 +24,7 @@ import numpy as np
 from docopt import docopt
 
 from perlin import apply_network_noise
+from render import display_network
 
 if 'SUMO_HOME' in os.environ:
     tools = os.path.join(os.environ['SUMO_HOME'], 'tools')
@@ -107,3 +109,6 @@ if __name__ == "__main__":
 
     # Write statistics back
     stats.write(args["--output-file"])
+
+    if (args["--display"]):
+        display_network(net, stats, 500, 500)

--- a/render.py
+++ b/render.py
@@ -4,7 +4,7 @@ import noise
 import numpy as np
 import math
 import xml.etree.ElementTree as ET
-from PIL import Image, ImageOps, ImageChops
+from PIL import Image, ImageOps, ImageChops, ImageDraw
 
 from perlin import get_perlin_noise, POPULATION_BASE, INDUSTRY_BASE
 from utility import find_city_centre, radius_of_network, distance
@@ -49,10 +49,16 @@ def display_network(net: sumolib.net.Net, stats: ET.ElementTree, width: int, hei
             arr[y][x] = p_noise + (1 - (distance((x / width_scale, y / height_scale), centre) / radius))  # FIXME: Duplicate code
     ind_img = toimage(arr)
 
-    pop_img = ImageOps.colorize(pop_img, (0, 0, 0), (0, 200, 0))
-    ind_img = ImageOps.colorize(ind_img, (0, 0, 0), (0, 0, 200))
+    pop_img = ImageOps.colorize(pop_img, (0, 0, 0), (0, 220, 0))
+    ind_img = ImageOps.colorize(ind_img, (0, 0, 0), (0, 0, 220))
 
     combined = ImageChops.add(pop_img, ind_img)
+
+    draw = ImageDraw.Draw(combined)
+    for edge in net.getEdges():
+        x1, y1 = edge.getFromNode().getCoord()
+        x2, y2 = edge.getToNode().getCoord()
+        draw.line([x1 * width_scale, y1 * height_scale, x2 * width_scale, y2 * height_scale], (255, 0, 0), 3)
 
     combined.show()
 


### PR DESCRIPTION
Currently it draws cities like this when you add the `--display` option:

![billede](https://user-images.githubusercontent.com/21122471/78245981-ace2c980-74e8-11ea-9314-f81284180a2e.png)

Green: Population
Blue: Industry
Red: City gates
The width of the roads are also determined by population

 As more elements are added, we will add them to the rendering.