### PR TITLE
[perlin] Scale noise based on the city's size

### DIFF
--- a/perlin.py
+++ b/perlin.py
@@ -50,23 +50,24 @@ def get_perlin_noise(x: float, y: float, base: int, scale: float = 0.005, octave
 
 
 def get_population_number(edge: sumolib.net.edge.Edge, base: int, centre,
-                          radius, scale: float = 0.005, octaves: int = 3) -> float:
+                          radius, centre_weight: float = 1.0, scale: float = 0.005, octaves: int = 3) -> float:
     """
     Returns a Perlin simplex noise at centre of given street
     :param base: offset into noisemap
     :param edge: the edge
     :param centre: centre of the city
     :param radius: radius of the city
+    :param centre_weight: how much impact being near the centre has
     :param scale: the scale to multiply to each coordinate, default is 0.005
     :param octaves: the octaves to use when sampling, default is 3
     :return: the scaled noise value as float in [0:1]
     """
     x, y = get_edge_pair_centroid(edge.getShape())
     return get_perlin_noise(x, y, base=base, scale=scale, octaves=octaves) + (
-            1 - (distance((x, y), centre) / radius))
+            1 - (distance((x, y), centre) / radius)) * centre_weight
 
 
-def apply_network_noise(net: sumolib.net.Net, xml: ElementTree, scale: float = 0.005, octaves: int = 3):
+def apply_network_noise(net: sumolib.net.Net, xml: ElementTree):
     """
     Calculate and apply Perlin noise in [0:1] range for each street for population and industry
     :param net: the SUMO network
@@ -80,6 +81,7 @@ def apply_network_noise(net: sumolib.net.Net, xml: ElementTree, scale: float = 0
 
     centre = find_city_centre(net)
     radius = radius_of_network(net, centre)
+    noise_scale = 3.5 / radius
 
     streets = xml.find("streets")
     if streets is None:
@@ -92,10 +94,10 @@ def apply_network_noise(net: sumolib.net.Net, xml: ElementTree, scale: float = 0
         eid = edge.getID()
         if eid not in known_streets:
             # This edge is missing a street entry. Find population and industry for this edge
-            population = get_population_number(edge=edge, base=POPULATION_BASE, scale=scale, octaves=octaves,
-                                               centre=centre, radius=radius)
-            industry = get_population_number(edge=edge, base=INDUSTRY_BASE, scale=scale, octaves=octaves,
-                                             centre=centre, radius=radius)
+            population = get_population_number(edge=edge, base=POPULATION_BASE, scale=noise_scale, octaves=3,
+                                               centre=centre, radius=radius, centre_weight=0.8)
+            industry = get_population_number(edge=edge, base=INDUSTRY_BASE, scale=noise_scale, octaves=3,
+                                             centre=centre, radius=radius, centre_weight=0.1)
 
             ET.SubElement(streets, "street", {
                 "edge": eid,

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -142,7 +142,7 @@ def main():
     verify_stats(stats)
 
     # Scale and octave seems like sane values for the moment
-    apply_network_noise(net, stats, 0.005, 3)
+    apply_network_noise(net, stats)
 
     setup_city_gates(net, stats, int(args["--gates.count"]))
 

--- a/render.py
+++ b/render.py
@@ -51,7 +51,7 @@ def display_network(net: sumolib.net.Net, stats: ET.ElementTree, max_width: int,
         x1, y1 = edge.getFromNode().getCoord()
         x2, y2 = edge.getToNode().getCoord()
         green = int(min(max(0, population * 190 - 30), 255))
-        blue = int(min(max(0, industry * 255 - 25), 255))
+        blue = int(min(max(0, industry * 255 - 20), 255))
         draw.line([x1 * width_scale, y1 * height_scale, x2 * width_scale, y2 * height_scale], (0, green, blue), int(0.5 + population * 4))
 
     # Draw city gates

--- a/render.py
+++ b/render.py
@@ -50,8 +50,8 @@ def display_network(net: sumolib.net.Net, stats: ET.ElementTree, max_width: int,
         industry = float(street_xml.attrib["workPosition"])
         x1, y1 = edge.getFromNode().getCoord()
         x2, y2 = edge.getToNode().getCoord()
-        green = int(min(max(0, population * 180 - 30), 255))
-        blue = int(min(max(0, industry * 180 - 30), 255))
+        green = int(min(max(0, population * 190 - 30), 255))
+        blue = int(min(max(0, industry * 255 - 25), 255))
         draw.line([x1 * width_scale, y1 * height_scale, x2 * width_scale, y2 * height_scale], (0, green, blue), int(0.5 + population * 4))
 
     # Draw city gates


### PR DESCRIPTION
* The noise scale is now `noise_scale = 3.5 / radius` which seems to fit for all the cities I tried.
* Added a weight to the gradient, so the industry gradient can be less heavy
* Adjusted rendering

Examples:
![billede](https://user-images.githubusercontent.com/21122471/78336421-9a6f9b00-758f-11ea-9bdb-2dcb739be8cd.png)
![billede](https://user-images.githubusercontent.com/21122471/78336482-b70bd300-758f-11ea-9045-734eaf68ba25.png)
![billede](https://user-images.githubusercontent.com/21122471/78336362-875ccb00-758f-11ea-9ad0-89a9f30b8ebf.png)
