### PR TITLE
[seed] Adds ability to seed the program

### DIFF
--- a/perlin.py
+++ b/perlin.py
@@ -17,12 +17,9 @@ else:
 
 import sumolib
 
-# The 'noise' lib has good resolution until above 10 mil, but a SIGSEGV is had on values above [-100000, 100000]
-# FIXME: these values result in a noisemap which contains CRT-like lines and patterns. Find better, sane values.
-# POPULATION_BASE = random.randrange(-1000, 1000)
-POPULATION_BASE = 4
-# INDUSTRY_BASE = random.randrange(-1000, 1000)
-INDUSTRY_BASE = 1
+
+POPULATION_BASE = -1  # Initialized in main
+INDUSTRY_BASE = -1  # Initialized in main
 
 
 def get_edge_pair_centroid(coords: List[Tuple[float, float]]) -> Tuple[float, float]:
@@ -46,7 +43,7 @@ def get_perlin_noise(x: float, y: float, base: int, scale: float = 0.005, octave
     :param octaves: the octaves to use when sampling, default is 3
     :return: a normalised float of the sample in noisemap
     """
-    return (noise.pnoise2(x=x * scale, y=y * scale, octaves=octaves, base=base) + 1) / 2
+    return (noise.pnoise3(x=x * scale, y=y * scale, z=base, octaves=octaves) + 1) / 2
 
 
 def get_population_number(edge: sumolib.net.edge.Edge, base: int, centre,

--- a/perlin.py
+++ b/perlin.py
@@ -36,9 +36,9 @@ def get_edge_pair_centroid(coords: List[Tuple[float, float]]) -> Tuple[float, fl
 def get_perlin_noise(x: float, y: float, base: int, scale: float = 0.005, octaves: int = 3) -> float:
     """
     The 'noise' lib returns a value in the range of [-1:1]. The noise value is scaled to the range of [0:1].
-    :param base: offset into noisemap
     :param x: the sample point for x
     :param y: the sample point for y
+    :param base: the offset for the 2d slice
     :param scale: the scale to multiply to each coordinate, default is 0.005
     :param octaves: the octaves to use when sampling, default is 3
     :return: a normalised float of the sample in noisemap

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -1,5 +1,5 @@
 """
-Usage: randomActivityGen.py --net-file=FILE --stat-file=FILE --output-file=FILE [--gates.count=N] [--display]
+Usage: randomActivityGen.py --net-file=FILE --stat-file=FILE --output-file=FILE [--gates.count=N] [--display] [--seed=S | --random]
 
 Input Options:
     -n, --net-file FILE         Input road network file to create activity for
@@ -11,6 +11,8 @@ Output Options:
 Other Options:
     --gates.count N             Number of city gates in the city [default: 4]
     --display                   Displays an image of cities elements and the noise used to generate them.
+    --seed S                    Initialises the random number generator with the given value S [default: 31415]
+    --random                    Initialises the random number generator with the current system time [default: false]
     -h, --help                  Show this screen.
     --version                   Show version.
 """
@@ -133,6 +135,14 @@ def verify_stats(stats: ET.ElementTree):
 
 def main():
     args = docopt(__doc__, version="RandomActivityGen v0.1")
+
+    if not args["--random"]:
+        random.seed(args["--seed"])
+    # The 'noise' lib has good resolution until above 10 mil, but a SIGSEGV is had on values above [-100000, 100000]
+    import perlin
+    perlin.POPULATION_BASE = random.randint(0, 65_536)
+    perlin.INDUSTRY_BASE = random.randint(0, 65_536)
+    while perlin.POPULATION_BASE == perlin.INDUSTRY_BASE: perlin.INDUSTRY_BASE = random.randint(0, 65_536)
 
     # Read in SUMO network
     net = sumolib.net.readNet(args["--net-file"])


### PR DESCRIPTION
Added seeding options similar to those of [ActivityGen](https://sumo.dlr.de/docs/ACTIVITYGEN.html#random_number).

```
    --seed S          Initialises the random number generator with the given value S [default: 31415]
    --random          Initialises the random number generator with the current system time [default: false]
```

Also looked deeper into the noise lib, and it seems like people recommend using the z component as they seeded offset into the noise instead of base, so I changed our noise to use z instead of base.