### PR TITLE
[logging] Add logging functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore logfile
+randomActivityGen-log.txt
+
 .idea
 out
 __pycache__

--- a/perlin.py
+++ b/perlin.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 import xml.etree.ElementTree as ET
@@ -75,11 +76,10 @@ def apply_network_noise(net: sumolib.net.Net, xml: ElementTree, scale: float = 0
     :param octaves: the octaves to use when sampling, default is 3
     :return:
     """
-    # Calculate and apply Perlin noise for all edges in network to population in statistics
-    print("Writing Perlin noise to population and industry")
-
     centre = find_city_centre(net)
+    logging.debug(f"City centre: {centre}")
     radius = radius_of_network(net, centre)
+    logging.debug(f"City radius: {radius:.2f}")
 
     streets = xml.find("streets")
     if streets is None:
@@ -97,6 +97,7 @@ def apply_network_noise(net: sumolib.net.Net, xml: ElementTree, scale: float = 0
             industry = get_population_number(edge=edge, base=INDUSTRY_BASE, scale=scale, octaves=octaves,
                                              centre=centre, radius=radius)
 
+            logging.debug(f"Adding street with eid: {eid},\t population: {population:.4f}, industry: {industry:.4f}")
             ET.SubElement(streets, "street", {
                 "edge": eid,
                 "population": str(population),

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -109,7 +109,8 @@ def verify_stats(stats: ET.ElementTree):
     """
     city = stats.getroot()
     assert city.tag == "city", "Stat file does not seem to be a valid stat file. The root element is not city"
-    # According to ActivityGen (https://github.com/eclipse/sumo/blob/master/src/activitygen/AGActivityGenHandler.cpp#L124-L161)
+    # According to ActivityGen
+    # (https://github.com/eclipse/sumo/blob/master/src/activitygen/AGActivityGenHandler.cpp#L124-L161)
     # only general::inhabitants and general::households are required. Everything else has default values.
     general = stats.find("general")
     # TODO Maybe guestimate the number of inhabitants and households based on the network's size
@@ -146,16 +147,14 @@ def main():
     # Setup logging
     logger = logging.getLogger()
     log_stream_handler = logging.StreamHandler(sys.stdout)
-    # Setup file logger, use given or default filename, and overwrite logs on each run
-    log_file_handler = logging.FileHandler(filename=args["--log-file"], mode="w")
     # Write log-level and indent slightly for message
     stream_formatter = logging.Formatter('%(levelname)-8s %(message)s')
+
+    # Setup file logger, use given or default filename, and overwrite logs on each run
+    log_file_handler = logging.FileHandler(filename=args["--log-file"], mode="w")
     # Use more verbose format for logfile
-    log_file_handler.setFormatter(logging.Formatter("%(asctime)s,%(msecs)d %(levelname)-8s %(message)s"))
+    log_file_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s %(message)s"))
     log_stream_handler.setFormatter(stream_formatter)
-    logger.addHandler(log_stream_handler)
-    # FIXME: logfile should always print in DEBUG
-    logger.addHandler(log_file_handler)
 
     # Parse log-level
     if args["--quiet"]:
@@ -165,7 +164,15 @@ def main():
     else:
         log_level = getattr(logging, str(args["--log-level"]).upper())
 
+    # Set log-levels and add handlers
+    log_file_handler.setLevel(log_level)
+    logger.addHandler(log_stream_handler)
     logger.setLevel(log_level)
+
+    # FIXME: logfile should always print in DEBUG, this seems like a larger hurdle:
+    # https://stackoverflow.com/questions/25187083/python-logging-to-multiple-handlers-at-different-log-levels
+    log_file_handler.setLevel(logging.DEBUG)
+    logger.addHandler(log_file_handler)
 
     # Read in SUMO network
     logging.info(f"Reading network from: {args['--net-file']}")

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -143,7 +143,7 @@ def main():
     args = docopt(__doc__, version="RandomActivityGen v0.1")
 
     logger = logging.getLogger()
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter('%(levelname)-8s %(message)s')
     handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -1,5 +1,5 @@
-"""
-Usage: randomActivityGen.py --net-file=FILE --stat-file=FILE --output-file=FILE [--gates.count=N] [--display]
+"""Usage: randomActivityGen.py --net-file=FILE --stat-file=FILE --output-file=FILE [--gates.count=N] [--display]
+    [--verbose] [--log-level=LEVEL]
 
 Input Options:
     -n, --net-file FILE         Input road network file to create activity for
@@ -11,6 +11,8 @@ Output Options:
 Other Options:
     --gates.count N             Number of city gates in the city [default: 4]
     --display                   Displays an image of cities elements and the noise used to generate them.
+    --verbose                   Sets log-level to DEBUG
+    --log-level=<LEVEL>         Explicitly set log-level {DEBUG, INFO, WARN, ERROR, CRITICAL} [default: WARN]
     -h, --help                  Show this screen.
     --version                   Show version.
 """
@@ -19,6 +21,7 @@ import os
 import random
 import sys
 import xml.etree.ElementTree as ET
+import logging
 
 import numpy as np
 from docopt import docopt
@@ -134,10 +137,27 @@ def verify_stats(stats: ET.ElementTree):
 def main():
     args = docopt(__doc__, version="RandomActivityGen v0.1")
 
+    logger = logging.getLogger()
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter('%(levelname)-8s %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    # Set log-level to verbose if set, otherwise log-level which defaults to WARNING
+    logger.setLevel(logging.DEBUG if args["--verbose"] else getattr(logging, str(args["--log-level"]).upper()))
+
+    # Log test
+    logger.debug("debug message")
+    logger.info("info message")
+    logger.warning("warn message")
+    logger.error("error message")
+    logger.critical("critical message")
+
     # Read in SUMO network
     net = sumolib.net.readNet(args["--net-file"])
 
     # Parse statistics configuration
+    logging.info(f"Parsing stat file: {args['--stat-file']}")
     stats = ET.parse(args["--stat-file"])
     verify_stats(stats)
 

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -1,5 +1,5 @@
 """Usage: randomActivityGen.py --net-file=FILE --stat-file=FILE --output-file=FILE [--gates.count=N] [--display]
-    [--verbose] [--log-level=LEVEL]
+    ([--quiet] | [--verbose] | [--log-level=LEVEL])
 
 Input Options:
     -n, --net-file FILE         Input road network file to create activity for
@@ -12,6 +12,7 @@ Other Options:
     --gates.count N             Number of city gates in the city [default: 4]
     --display                   Displays an image of cities elements and the noise used to generate them.
     --verbose                   Sets log-level to DEBUG
+    --quiet                     Sets log-level to ERROR
     --log-level=<LEVEL>         Explicitly set log-level {DEBUG, INFO, WARN, ERROR, CRITICAL} [default: WARN]
     -h, --help                  Show this screen.
     --version                   Show version.
@@ -22,7 +23,6 @@ import random
 import sys
 import xml.etree.ElementTree as ET
 import logging
-
 import numpy as np
 from docopt import docopt
 
@@ -143,8 +143,15 @@ def main():
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
-    # Set log-level to verbose if set, otherwise log-level which defaults to WARNING
-    logger.setLevel(logging.DEBUG if args["--verbose"] else getattr(logging, str(args["--log-level"]).upper()))
+    # Parse log-level 
+    if args["--quiet"]:
+        log_level = logging.ERROR
+    elif args["--verbose"]:
+        log_level = logging.DEBUG
+    else:
+        log_level = getattr(logging, str(args["--log-level"]).upper())
+
+    logger.setLevel(log_level)
 
     # Log test
     logger.debug("debug message")

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -323,9 +323,9 @@ def main():
     stats.write(args["--output-file"])
 
     if args["--display"]:
-        x_size, y_size = 500, 500
-        logging.info(f"Displaying network as image sized: {x_size} x {y_size}")
-        display_network(net, stats, x_size, y_size, centre)
+        x_max_size, y_max_size = 500, 500
+        logging.info(f"Displaying network as image of max: {x_max_size} x {y_max_size} dimensions")
+        display_network(net, stats, x_max_size, y_max_size, centre)
 
 
 if __name__ == "__main__":

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -166,7 +166,12 @@ def setup_schools(net: sumolib.net.Net, stats: ET.ElementTree, school_count: int
     school_open_latest = int(args["--schools.open"].split(",")[1]) * 3600
     school_close_earliest = int(args["--schools.close"].split(",")[0]) * 3600
     school_close_latest = int(args["--schools.close"].split(",")[1]) * 3600
-    stepsize = int((float(args["--schools.stepsize"]) * 3600))
+    school_stepsize = int((float(args["--schools.stepsize"]) * 3600))
+    logging.debug(f"For school generation using:\n\tschool_open_earliest:\t {school_open_earliest}\n\t"
+                 f"school_open_latest:\t\t {school_open_latest}\n\t"
+                 f"school_close_earliest:\t {school_close_earliest}\n\t"
+                 f"school_close_latest:\t {school_close_latest}\n\t"
+                 f"school_stepsize:\t\t {school_stepsize}")
 
     # Find edges to place schools on
     new_school_edges = find_school_edges(net, number_new_schools)
@@ -179,6 +184,7 @@ def setup_schools(net: sumolib.net.Net, stats: ET.ElementTree, school_count: int
         end_age = random.randint(int(args["--schools.end-age"].split(",")[1]) if begin_age + 1 <= int(
             args["--schools.end-age"].split(",")[1]) else begin_age + 1,
                                  int(args["--schools.end-age"].split(",")[1]))
+        logging.debug(f"Using begin_age: {begin_age}, end_age: {end_age} for school(s)")
 
         ET.SubElement(xml_schools, "school", attrib={
             "edge": str(school.getID()),
@@ -187,8 +193,8 @@ def setup_schools(net: sumolib.net.Net, stats: ET.ElementTree, school_count: int
             "endAge": str(end_age),
             "capacity": str(random.randint(int(args["--schools.capacity"].split(",")[0]),
                                            int(args["--schools.capacity"].split(",")[1]))),
-            "opening": str(random.randrange(school_open_earliest, school_open_latest, stepsize)),
-            "closing": str(random.randrange(school_close_earliest, school_close_latest, stepsize))
+            "opening": str(random.randrange(school_open_earliest, school_open_latest, school_stepsize)),
+            "closing": str(random.randrange(school_close_earliest, school_close_latest, school_stepsize))
         })
 
 


### PR DESCRIPTION
Logging now works by using `logging.{debug, info, warning, error, critical}(msg)` and writes nicely formatted to stdout and file.

Existing prints and important places of debug, info, and warning has been converted to logging.

Note that log-levels are symmetric between stdout and file which is unintended, as logfile should always be verbose. This allows a user to look up a previous run if required. I was not able to solve it easily and have left a stack-link if we decide to pursue that feature further.