### PR TITLE
[display] Add --display-only option

### DIFF
--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -41,8 +41,6 @@ Other Options:
     --version                   Show version.
 """
 
-# FIXME: make --display-only option mutex with ordinary run
-
 import os
 import random
 import sys

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -138,7 +138,7 @@ def main():
     # If display-only, load stat-file as input and exit after rendering
     if args["--display-only"]:
         # Try the output-file first, as, if given, it contains a computed statistics file, otherwise try the input
-        stats = ET.parse(args["--output-file"] if not None else args["--stat-file"])
+        stats = ET.parse(args["--output-file"] or args["--stat-file"])
         logging.info(f"Displaying network as image of max size {max_display_size}x{max_display_size}")
         display_network(net, stats, max_display_size, centre, args["--net-file"])
         exit(0)

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -133,7 +133,7 @@ def main():
         map(int, args["--centre.pos"].split(",")))
 
     if args["--display-only"]:
-        stats = ET.parse(args["--input-file"])
+        stats = ET.parse(args["--stat-file"])
         x_max_size, y_max_size = 1000, 1000
         logging.info(f"Displaying network as image of max: {x_max_size} x {y_max_size} dimensions")
         display_network(net, stats, centre, args, x_max_size, y_max_size)

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -1,9 +1,10 @@
-"""Usage: randomActivityGen.py --net-file=FILE --stat-file=FILE --output-file=FILE [--centre.pos=args]
+"""Usage:
+    randomActivityGen.py --net-file=FILE --stat-file=FILE --output-file=FILE [--centre.pos=args]
     [--centre.pop-weight=F] [--centre.work-weight=F] [--gates.count=N] [--schools.count=N] [--schools.ratio=F]
     [--schools.stepsize=F] [--schools.open=args] [--schools.close=args]  [--schools.begin-age=args]
     [--schools.end-age=args] [--schools.capacity=args] [--bus-stop.distance=N] [--bus-stop.k=N] [--display]
     [--display.size=N] [--seed=S | --random] ([--quiet] | [--verbose] | [--log-level=LEVEL]) [--log-file=FILENAME]
-    [--display-only]
+    randomActivityGen.py --net-file=FILE --stat-file=FILE [--output-file=FILE] --display-only
 
 Input Options:
     -n, --net-file FILE         Input road network file to create activity for
@@ -131,14 +132,17 @@ def main():
     stats = ET.parse(args["--stat-file"])
     verify_stats(stats)
 
+    max_display_size = int(args["--display.size"])
+
     centre = find_city_centre(net) if args["--centre.pos"] == "auto" else tuple(
         map(int, args["--centre.pos"].split(",")))
 
+    # If display-only, load stat-file as input and exit after rendering
     if args["--display-only"]:
-        stats = ET.parse(args["--stat-file"])
-        x_max_size, y_max_size = 1000, 1000
-        logging.info(f"Displaying network as image of max: {x_max_size} x {y_max_size} dimensions")
-        display_network(net, stats, centre, args, x_max_size, y_max_size)
+        # Try the output-file first, as, if given, it contains a computed statistics file, otherwise try the input
+        stats = ET.parse(args["--output-file"] if not None else args["--stat-file"])
+        logging.info(f"Displaying network as image of max size {max_display_size}x{max_display_size}")
+        display_network(net, stats, max_display_size, centre, args["--net-file"])
         exit(0)
 
     logging.info("Writing Perlin noise to population and industry")
@@ -167,9 +171,8 @@ def main():
     stats.write(args["--output-file"])
 
     if args["--display"]:
-        max_size = int(args["--display.size"])
-        logging.info(f"Displaying network as image of max size {max_size}x{max_size}")
-        display_network(net, stats, max_size, centre, args["--net-file"])
+        logging.info(f"Displaying network as image of max size {max_display_size}x{max_display_size}")
+        display_network(net, stats, max_display_size, centre, args["--net-file"])
 
 
 if __name__ == "__main__":

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -1,8 +1,8 @@
 """Usage: randomActivityGen.py --net-file=FILE --stat-file=FILE --output-file=FILE [--centre.pos=args]
     [--centre.pop-weight=F] [--centre.work-weight=F] [--gates.count=N] [--schools.count=N] [--schools.ratio=F]
-    [--schools.stepsize=F] [--schools.open=args] [--schools.close=args]  [--schools.begin-age=args]
+    [--schools.stepsize=F] [--schools.open=args] [--schools.close=args] [--schools.begin-age=args]
     [--schools.end-age=args] [--schools.capacity=args] [--bus-stop.distance=N] [--bus-stop.k=N] [--display] [--seed=S | --random]
-    ([--quiet] | [--verbose] | [--log-level=LEVEL]) [--log-file=FILENAME]
+    ([--quiet] | [--verbose] | [--log-level=LEVEL]) [--log-file=FILENAME] [--display-only]
 
 Input Options:
     -n, --net-file FILE         Input road network file to create activity for
@@ -26,7 +26,8 @@ Other Options:
     --schools.capacity=args     The range for capacity in schools [default: 100,500]
     --bus-stop.distance N       Minimum distance between bus stops [default: 500]
     --bus-stop.k N              Placement attempts in the poisson-disc algorithm [default: 10]
-    --display                   Displays an image of cities elements and the noise used to generate them.
+    --display                   Displays an image of city elements and the noise used to generate them.
+    --display-only              Displays an image of city elements from existing statistics file. If given uses --stat-file for input.
     --verbose                   Sets log-level to DEBUG
     --quiet                     Sets log-level to ERROR
     --log-level=<LEVEL>         Explicitly set log-level {DEBUG, INFO, WARN, ERROR, CRITICAL} [default: INFO]
@@ -36,6 +37,8 @@ Other Options:
     -h, --help                  Show this screen.
     --version                   Show version.
 """
+
+# FIXME: make --display-only option mutex with ordinary run
 
 import os
 import random
@@ -126,9 +129,17 @@ def main():
     stats = ET.parse(args["--stat-file"])
     verify_stats(stats)
 
-    logging.info("Writing Perlin noise to population and industry")
     centre = find_city_centre(net) if args["--centre.pos"] == "auto" else tuple(
         map(int, args["--centre.pos"].split(",")))
+
+    if args["--display-only"]:
+        stats = ET.parse(args["--input-file"])
+        x_max_size, y_max_size = 1000, 1000
+        logging.info(f"Displaying network as image of max: {x_max_size} x {y_max_size} dimensions")
+        display_network(net, stats, centre, args, x_max_size, y_max_size)
+        exit(0)
+
+    logging.info("Writing Perlin noise to population and industry")
 
     # Populate network with street data
     logging.debug(f"Using centre: {centre}, "
@@ -156,7 +167,7 @@ def main():
     if args["--display"]:
         x_max_size, y_max_size = 1000, 1000
         logging.info(f"Displaying network as image of max: {x_max_size} x {y_max_size} dimensions")
-        display_network(net, stats, x_max_size, y_max_size)
+        display_network(net, stats, centre, args, x_max_size, y_max_size)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [x] Figure out how to make `--display-only` option mutex with ordinary run. 
E.g. `ranactgen.py -n test.net.xml -s test.stat.xml -o test2.stat.xml` 
and `ranactgen.py -n test.net.xml -s test2.stat.xml --display-only` should both be minimum legal arguments.

Fixes #42, ~~depends #43~~

The parser help-msg now looks like this: 
```
Usage:
    randomActivityGen.py --net-file=FILE --stat-file=FILE --output-file=FILE [--centre.pos=args]
    [--centre.pop-weight=F] [--centre.work-weight=F] [--gates.count=N] [--schools.count=N] [--schools.ratio=F]
    [--schools.stepsize=F] [--schools.open=args] [--schools.close=args]  [--schools.begin-age=args]
    [--schools.end-age=args] [--schools.capacity=args] [--bus-stop.distance=N] [--bus-stop.k=N] [--display]
    [--display.size=N] [--seed=S | --random] ([--quiet] | [--verbose] | [--log-level=LEVEL]) [--log-file=FILENAME]
    randomActivityGen.py --net-file=FILE --stat-file=FILE [--output-file=FILE] --display-only
```
Note how the first and last line contain the program name. Either of those are now legal. When `--display-only` is given, the output stat file is attempted to be read first, otherwise the input will be attempted.

This behaviour ensures a user can simply append `-only` (from `--display` to `--display-only`) to their arguments to quickly reload the already computed statistics for rendering. This is especially helpful for very large computations.

A flow could look like:
Computing the statistics and render it:
`x.py --net-file=x.net.xml --stat-file=stat-input.stat.xml --output-file=stat-output.stat.xml --display`
Render the statistics after the fact:
`x.py --net-file=x.net.xml --stat-file=stat-input.stat.xml --output-file=stat-output.stat.xml --display-only`
or
`x.py --net-file=x.net.xml --stat-file=stat-output.stat.xml --display-only`