### PR TITLE
[city-gates] Make city gates distinct

### DIFF
--- a/gates.py
+++ b/gates.py
@@ -49,7 +49,7 @@ def setup_city_gates(net: sumolib.net.Net, stats: ET.ElementTree, gate_count: in
 
     for direction in directions:
         # Find the dead ends furthest in each direction using the dot product and argmax. Those nodes will be our gates.
-        # Duplicates are possible and no problem. That just means there will be more traffic through that gate.
+        # Dead ends are removed from the list to avoid duplicates.
         gate_index = int(np.argmax([np.dot(node.getCoord(), direction) for node in dead_ends]))
         gate = dead_ends[gate_index]
         dead_ends.remove(gate)

--- a/gates.py
+++ b/gates.py
@@ -43,9 +43,8 @@ def setup_city_gates(net: sumolib.net.Net, stats: ET.ElementTree, gate_count: in
     # W<---o--->E
     #      |
     #      S
-    tau = math.pi * 2
-    base_rad = random.random() * tau
-    rads = [(base_rad + i * tau / n) % tau for i in range(0, n)]
+    base_rad = random.random() * math.tau
+    rads = [(base_rad + i * math.tau / n) % math.tau for i in range(0, n)]
     directions = [(math.cos(rad), math.sin(rad)) for rad in rads]
 
     for direction in directions:
@@ -53,6 +52,7 @@ def setup_city_gates(net: sumolib.net.Net, stats: ET.ElementTree, gate_count: in
         # Duplicates are possible and no problem. That just means there will be more traffic through that gate.
         gate_index = int(np.argmax([np.dot(node.getCoord(), direction) for node in dead_ends]))
         gate = dead_ends[gate_index]
+        dead_ends.remove(gate)
 
         # Decide proportion of the incoming and outgoing vehicles coming through this gate
         # These numbers are relatively to the values of the other gates


### PR DESCRIPTION
Previously it was possible that the same dead end was picked multiple times as a city gate. Now city gates must be distinct dead ends.