### PR TITLE
[test] Add tripsToCSV.py

### DIFF
--- a/tripsToCSV.py
+++ b/tripsToCSV.py
@@ -11,6 +11,7 @@ import os
 import sys
 import csv
 import xml.etree.ElementTree as ET
+import random
 
 from PIL import Image, ImageDraw
 from docopt import docopt
@@ -51,10 +52,12 @@ with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-starts.csv", "
         for edge in net.getEdges():
 
             # Find all trips that starts on this edge and save the position along the edge
-            trip_starts = [(float(trip.attrib["departPos"]), float(trip.attrib["depart"])) for trip in trips.findall("trip") if trip.attrib["from"] == edge.getID()]
+            trip_starts = [(trip.get("departPos"), float(trip.get("depart"))) for trip in trips.findall("trip") if trip.get("from") == edge.getID()]
 
             # Add trip start data points
             for (departPos, departTime) in trip_starts:
+                if departPos is None:
+                    departPos = edge.getLength() * random.random()
                 x, y = position_on_edge(edge, departPos)
                 x -= offset_x
                 y -= offset_y

--- a/tripsToCSV.py
+++ b/tripsToCSV.py
@@ -32,10 +32,12 @@ args = docopt(__doc__)
 net = sumolib.net.readNet(args["--net-file"])
 trips = ET.parse(args["--trips-file"])
 
+# Info about net size and edges
 offset_x, offset_y, xmax, ymax = net.getBoundary()
 net_width, net_height = xmax - offset_x, ymax - offset_y
 edge_count = len(net.getEdges())
 
+# base of file name, e.g. "vejen.trips.rou.xml" -> "vejen"
 fname = os.path.splitext(os.path.splitext(os.path.splitext(os.path.basename(args["--trips-file"]))[0])[0])[0]
 
 starts = []
@@ -50,9 +52,11 @@ with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-starts.csv", "
         progress = 0
         for edge in net.getEdges():
 
+            # Find all trips that starts and ends on this edge and save the position along the edge
             trip_starts = [float(trip.attrib["arrivalPos"]) for trip in trips.findall("trip") if trip.attrib["from"] == edge.getID()]
             trip_ends = [float(trip.attrib["departPos"]) for trip in trips.findall("trip") if trip.attrib["to"] == edge.getID()]
 
+            # Add trip start data points
             for start in trip_starts:
                 x, y = position_on_edge(edge, start)
                 x -= offset_x
@@ -61,6 +65,7 @@ with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-starts.csv", "
                 writer_starts.writerow(start)
                 starts.append(start)
 
+            # Add trip end data points
             for end in trip_ends:
                 x, y = position_on_edge(edge, end)
                 x -= offset_x
@@ -69,7 +74,15 @@ with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-starts.csv", "
                 writer_starts.writerow(end)
                 ends.append(end)
 
+            # Print a . whenever another 10% is done
+            progress += 1
+            if progress > next_print:
+                next_print += 0.1 * edge_count
+                print(".", end="")
+
+# Display the start and end positions
 if args["--display"]:
+    # Calculate dimensions and scaling
     max_size = 800
     width_height_relation = net_height / net_width
     if net_width > net_height:
@@ -81,6 +94,7 @@ if args["--display"]:
     width_scale = width / net_width
     height_scale = height / net_height
 
+    # Render start points
     img = Image.new("RGB", (width, height), (255, 255, 255))
     draw = ImageDraw.Draw(img, "RGBA")
     for point in starts:
@@ -92,6 +106,7 @@ if args["--display"]:
         draw.ellipse([x - r, y - r, x + r, y + r], fill=color)
     img.show()
 
+    # Render end points
     img = Image.new("RGB", (width, height), (255, 255, 255))
     draw = ImageDraw.Draw(img, "RGBA")
     for point in ends:

--- a/tripsToCSV.py
+++ b/tripsToCSV.py
@@ -50,26 +50,24 @@ with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-starts.csv", "
         progress = 0
         for edge in net.getEdges():
 
-            trip_starts = len([trip for trip in trips.findall("trip") if trip.attrib["from"] == edge.getID()])
-            trip_ends = len([trip for trip in trips.findall("trip") if trip.attrib["to"] == edge.getID()])
+            trip_starts = [float(trip.attrib["arrivalPos"]) for trip in trips.findall("trip") if trip.attrib["from"] == edge.getID()]
+            trip_ends = [float(trip.attrib["departPos"]) for trip in trips.findall("trip") if trip.attrib["to"] == edge.getID()]
 
-            x, y = position_on_edge(edge, edge.getLength() / 2)
-            x -= offset_x
-            y -= offset_y
+            for start in trip_starts:
+                x, y = position_on_edge(edge, start)
+                x -= offset_x
+                y -= offset_y
+                start = (x, y)
+                writer_starts.writerow(start)
+                starts.append(start)
 
-            start = (x, y, trip_starts)
-            end = (x, y, trip_ends)
-
-            writer_starts.writerow(start)
-            writer_ends.writerow(end)
-
-            starts.append(start)
-            ends.append(end)
-
-            progress += 1
-            if progress > next_print:
-                next_print += 0.1 * edge_count
-                print(".", end="")
+            for end in trip_ends:
+                x, y = position_on_edge(edge, end)
+                x -= offset_x
+                y -= offset_y
+                end = (x, y)
+                writer_starts.writerow(end)
+                ends.append(end)
 
 if args["--display"]:
     max_size = 800
@@ -86,12 +84,10 @@ if args["--display"]:
     img = Image.new("RGB", (width, height), (255, 255, 255))
     draw = ImageDraw.Draw(img, "RGBA")
     for point in starts:
-        x, y, c = point
-        if c == 0:
-            continue
+        x, y = point
         x *= width_scale
         y = (net_height - y) * height_scale
-        color = (0, min(255, 40 * c), 0)
+        color = (0, 200, 0)
         r = 2
         draw.ellipse([x - r, y - r, x + r, y + r], fill=color)
     img.show()
@@ -99,12 +95,10 @@ if args["--display"]:
     img = Image.new("RGB", (width, height), (255, 255, 255))
     draw = ImageDraw.Draw(img, "RGBA")
     for point in ends:
-        x, y, c = point
-        if c == 0:
-            continue
+        x, y = point
         x *= width_scale
         y = (net_height - y) * height_scale
-        color = (0, 0, min(255, 40 * c))
+        color = (0, 0, 200)
         r = 2
         draw.ellipse([x - r, y - r, x + r, y + r], fill=color)
     img.show()

--- a/tripsToCSV.py
+++ b/tripsToCSV.py
@@ -31,6 +31,10 @@ args = docopt(__doc__)
 net = sumolib.net.readNet(args["--net-file"])
 trips = ET.parse(args["--trips-file"])
 
+offset_x, offset_y, xmax, ymax = net.getBoundary()
+width, height = xmax - offset_x, ymax - offset_y
+edge_count = len(net.getEdges())
+
 fname = os.path.splitext(os.path.splitext(os.path.splitext(os.path.basename(args["--trips-file"]))[0])[0])[0]
 
 with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-starts.csv", "w", newline="") as csv_starts:
@@ -38,7 +42,6 @@ with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-starts.csv", "
         writer_starts = csv.writer(csv_starts)
         writer_ends = csv.writer(csv_ends)
 
-        edge_count = len(net.getEdges())
         next_print = 0.1 * edge_count
         progress = 0
         for edge in net.getEdges():
@@ -47,6 +50,8 @@ with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-starts.csv", "
             tripEnds = len([trip for trip in trips.findall("trip") if trip.attrib["to"] == edge.getID()])
 
             x, y = position_on_edge(edge, edge.getLength() / 2)
+            x -= offset_x
+            y -= offset_y
 
             writer_starts.writerow([x, y, tripStarts])
             writer_ends.writerow([x, y, tripEnds])

--- a/tripsToCSV.py
+++ b/tripsToCSV.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    tripsToCSV.py --net-file=FILE --trips-file=FILE
+    tripsToCSV.py --net-file=FILE --trips-file=FILE [--display]
 
 Input Options:
     -n, --net-file FILE         Input road network
@@ -12,6 +12,7 @@ import sys
 import csv
 import xml.etree.ElementTree as ET
 
+from PIL import Image, ImageDraw
 from docopt import docopt
 
 from utility import position_on_edge
@@ -32,10 +33,13 @@ net = sumolib.net.readNet(args["--net-file"])
 trips = ET.parse(args["--trips-file"])
 
 offset_x, offset_y, xmax, ymax = net.getBoundary()
-width, height = xmax - offset_x, ymax - offset_y
+net_width, net_height = xmax - offset_x, ymax - offset_y
 edge_count = len(net.getEdges())
 
 fname = os.path.splitext(os.path.splitext(os.path.splitext(os.path.basename(args["--trips-file"]))[0])[0])[0]
+
+starts = []
+ends = []
 
 with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-starts.csv", "w", newline="") as csv_starts:
     with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-ends.csv", "w", newline="") as csv_ends:
@@ -46,17 +50,61 @@ with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-starts.csv", "
         progress = 0
         for edge in net.getEdges():
 
-            tripStarts = len([trip for trip in trips.findall("trip") if trip.attrib["from"] == edge.getID()])
-            tripEnds = len([trip for trip in trips.findall("trip") if trip.attrib["to"] == edge.getID()])
+            trip_starts = len([trip for trip in trips.findall("trip") if trip.attrib["from"] == edge.getID()])
+            trip_ends = len([trip for trip in trips.findall("trip") if trip.attrib["to"] == edge.getID()])
 
             x, y = position_on_edge(edge, edge.getLength() / 2)
             x -= offset_x
             y -= offset_y
 
-            writer_starts.writerow([x, y, tripStarts])
-            writer_ends.writerow([x, y, tripEnds])
+            start = (x, y, trip_starts)
+            end = (x, y, trip_ends)
+
+            writer_starts.writerow(start)
+            writer_ends.writerow(end)
+
+            starts.append(start)
+            ends.append(end)
 
             progress += 1
             if progress > next_print:
                 next_print += 0.1 * edge_count
                 print(".", end="")
+
+if args["--display"]:
+    max_size = 800
+    width_height_relation = net_height / net_width
+    if net_width > net_height:
+        width = max_size
+        height = int(max_size * width_height_relation)
+    else:
+        width = int(max_size / width_height_relation)
+        height = max_size
+    width_scale = width / net_width
+    height_scale = height / net_height
+
+    img = Image.new("RGB", (width, height), (255, 255, 255))
+    draw = ImageDraw.Draw(img, "RGBA")
+    for point in starts:
+        x, y, c = point
+        if c == 0:
+            continue
+        x *= width_scale
+        y = (net_height - y) * height_scale
+        color = (0, min(255, 40 * c), 0)
+        r = 2
+        draw.ellipse([x - r, y - r, x + r, y + r], fill=color)
+    img.show()
+
+    img = Image.new("RGB", (width, height), (255, 255, 255))
+    draw = ImageDraw.Draw(img, "RGBA")
+    for point in ends:
+        x, y, c = point
+        if c == 0:
+            continue
+        x *= width_scale
+        y = (net_height - y) * height_scale
+        color = (0, 0, min(255, 40 * c))
+        r = 2
+        draw.ellipse([x - r, y - r, x + r, y + r], fill=color)
+    img.show()

--- a/tripsToCSV.py
+++ b/tripsToCSV.py
@@ -6,7 +6,7 @@ Input Options:
     -n, --net-file FILE         Input road network
     -s, --trips-file FILE       Input trips file
 """
-
+import datetime
 import os
 import sys
 import csv
@@ -113,8 +113,8 @@ if args["--png"] or args["--gif"]:
                 y = (net_height - y) * height_scale
                 r = 2
                 draw.ellipse([x - r, y - r, x + r, y + r], fill=(0, 0, 0))
-            draw.text((10, 10), f"t={timeslot}", fill=(0, 0, 0))
+            draw.text((10, 10), f"{datetime.timedelta(seconds=timeslot)} ({timeslot})", fill=(0, 0, 0))
             draw.line([0, 1, width * timeslot / 86400, 1], fill=(0, 0, 0))
             images.append(img)
 
-        images[0].save(f"out/cities/{fname}-trips.gif", save_all=True, append_images=images[1:], optimize=False, duration=10, loop=0)
+        images[0].save(f"out/cities/{fname}-trips.gif", save_all=True, append_images=images[1:], optimize=False, duration=8, loop=0)

--- a/tripsToCSV.py
+++ b/tripsToCSV.py
@@ -1,0 +1,57 @@
+"""
+Usage:
+    tripsToCSV.py --net-file=FILE --trips-file=FILE
+
+Input Options:
+    -n, --net-file FILE         Input road network
+    -s, --trips-file FILE       Input trips file
+"""
+
+import os
+import sys
+import csv
+import xml.etree.ElementTree as ET
+
+from docopt import docopt
+
+from utility import position_on_edge
+
+if 'SUMO_HOME' in os.environ:
+    tools = os.path.join(os.environ['SUMO_HOME'], 'tools')
+    sys.path.append(tools)
+else:
+    sys.exit("Please declare environment variable 'SUMO_HOME' to use sumolib")
+
+import sumolib
+
+
+args = docopt(__doc__)
+
+# Read input files
+net = sumolib.net.readNet(args["--net-file"])
+trips = ET.parse(args["--trips-file"])
+
+fname = os.path.splitext(os.path.splitext(os.path.splitext(os.path.basename(args["--trips-file"]))[0])[0])[0]
+
+with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-starts.csv", "w", newline="") as csv_starts:
+    with open(os.path.dirname(args["--trips-file"]) + f"/{fname}-trip-ends.csv", "w", newline="") as csv_ends:
+        writer_starts = csv.writer(csv_starts)
+        writer_ends = csv.writer(csv_ends)
+
+        edge_count = len(net.getEdges())
+        next_print = 0.1 * edge_count
+        progress = 0
+        for edge in net.getEdges():
+
+            tripStarts = len([trip for trip in trips.findall("trip") if trip.attrib["from"] == edge.getID()])
+            tripEnds = len([trip for trip in trips.findall("trip") if trip.attrib["to"] == edge.getID()])
+
+            x, y = position_on_edge(edge, edge.getLength() / 2)
+
+            writer_starts.writerow([x, y, tripStarts])
+            writer_ends.writerow([x, y, tripEnds])
+
+            progress += 1
+            if progress > next_print:
+                next_print += 0.1 * edge_count
+                print(".", end="")


### PR DESCRIPTION
The `tripsToCSV.py` does what it says on the package. It takes a net file and a trips file and creates a csv files. It contains the start positions and departure time of all the trips. Example:
```
# Trip start pos
# x, y, depart time
4828.151135541244,1449.691775245941
1731.1925678065309,3174.29292407896
1720.9972081797823,3337.3444850714304
1717.8943540410692,3386.967571394168
1719.3559156647316,3363.593221400634
```
These csv files will be used for tests. E.g. we can compare the resulting trips created by our tool with the trips from `randomTrips.py`, either using peacock or rendering.

If `--gif` is added as an argument, it will create a gif of the data points. See https://imgur.com/a/tClznrm. And `--png` will create 3 pngs of the trips: all trips, before 12h00, and after 12h00
