### PR TITLE
[gates] Make default gate count automatic

### DIFF
--- a/gates.py
+++ b/gates.py
@@ -16,8 +16,10 @@ else:
 import sumolib
 
 
-def setup_city_gates(net: sumolib.net.Net, stats: ET.ElementTree, gate_count: int):
+def setup_city_gates(net: sumolib.net.Net, stats: ET.ElementTree, gate_count: str, city_radius: float):
+    gate_count = find_gate_count_auto(city_radius) if gate_count == "auto" else int(gate_count)
     assert gate_count >= 0, "Number of city gates cannot be negative"
+
     # Find existing gates to determine how many we need to insert
     xml_gates = stats.find("cityGates")
     if xml_gates is None:
@@ -69,7 +71,7 @@ def setup_city_gates(net: sumolib.net.Net, stats: ET.ElementTree, gate_count: in
         edge, pos = (gate.getOutgoing()[0], 0) if len(gate.getOutgoing()) > 0 \
             else (gate.getIncoming()[0], gate.getIncoming()[0].getLength())
         logging.debug(
-            f"Adding entrance to statistics, edge: {edge.getID()}, incoming traffic: {incoming_traffic}, outgoing "
+            f"[gates] Adding entrance to statistics, edge: {edge.getID()}, incoming traffic: {incoming_traffic}, outgoing "
             f"traffic: {outgoing_traffic}")
         ET.SubElement(xml_gates, "entrance", attrib={
             "edge": edge.getID(),
@@ -77,3 +79,9 @@ def setup_city_gates(net: sumolib.net.Net, stats: ET.ElementTree, gate_count: in
             "outgoing": str(outgoing_traffic),
             "pos": str(pos)
         })
+
+
+def find_gate_count_auto(city_radius: float) -> int:
+    # Assume there's a gate very 1750 meters around the circumference
+    circumference = 2 * city_radius * math.pi
+    return int(circumference / 1750)

--- a/randomActivityGen.py
+++ b/randomActivityGen.py
@@ -20,7 +20,7 @@ Other Options:
     --centre.pos args           The coordinates for the city's centre, e.g. "300,500" or "auto" [default: auto]
     --centre.pop-weight F       The increase in population near the city center [default: 0.5]
     --centre.work-weight F      The increase in work places near the city center [default: 0.1]
-    --gates.count N             Number of city gates in the city [default: 4]
+    --gates.count N             Number of city gates in the city [default: auto]
     --schools.stepsize F        Stepsize in opening/closing hours, in parts of an hour, e.g 0.25 is every 15 mins [default: 0.25]
     --schools.open=args         The interval at which the schools opens (24h clock) [default: 7,10]
     --schools.close=args        The interval at which the schools closes (24h clock) [default: 13,17]
@@ -127,8 +127,8 @@ def main():
     logging.info("[main] Setting up streets with population and workplaces")
     setup_streets(net, stats, pop_noise, work_noise)
 
-    logging.debug(f"[main] Setting up {int(args['--gates.count'])} city gates")
-    setup_city_gates(net, stats, int(args["--gates.count"]))
+    logging.debug(f"[main] Setting up city gates")
+    setup_city_gates(net, stats, args["--gates.count"], radius)
 
     logging.info("[main] Setting up schools")
     setup_schools(args, net, stats, pop_noise)


### PR DESCRIPTION
Previously the gate count was always 4. Now it is estimated based on the cities circumference (radius). A quick informal test shows that a every 1750-ish meters fits our five test cities.